### PR TITLE
Fix volume path in Windows with spaces in pathname

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -1,4 +1,4 @@
-SET docker=docker run -it --rm -v %CD%:/diss andrerichter/tum-dissertation-latex
+SET docker=docker run -it --rm -v "%CD%":/diss andrerichter/tum-dissertation-latex
 
 IF "%1"=="crop" %docker% make crop-local
 IF "%1"=="" %docker% make pdf-local


### PR DESCRIPTION
Error message:

C:\Users\xxx yyy\Desktop\DISS>IF "crop" == "crop" docker run -it
--rm -v C:\Users\xxx yyy\Desktop\DISS:/diss
andrerichter/tum-dissertation-latex make crop-local
docker: invalid reference format.
See 'docker run --help'.

Reported by Markus Schill