### PR TITLE
Reverted texlive-fonts-extra and removed corresponding option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN set -x;                                       \
         texlive-lang-german                       \
         texlive-latex-extra                       \
         texlive-science                           \
-        texlive-fonts-extra                       \
         latexmk                                   \
         inkscape                                  \
         ;                                         \

--- a/inc/tumDiss.cls
+++ b/inc/tumDiss.cls
@@ -6,13 +6,10 @@
 \newif\if@titlepage@sansserif
 \DeclareOption{seriftitlepage}{\@titlepage@sansseriffalse}%
 \DeclareOption{sansseriftitlepage}{\@titlepage@sansseriftrue}%
-\newif\if@tumtext@sansserif
-\DeclareOption{seriftumtext}{\@tumtext@sansseriffalse}%
-\DeclareOption{sansseriftumtext}{\@tumtext@sansseriftrue}%
 % title page layout lines
 \newif\if@titlepage@showlayout
-\DeclareOption{layouttitlepage}{\@titlepage@showlayouttrue}
-\DeclareOption{nolayouttitlepage}{\@titlepage@showlayoutfalse}
+\DeclareOption{layouttitlepage}{\@titlepage@showlayouttrue}%
+\DeclareOption{nolayouttitlepage}{\@titlepage@showlayoutfalse}%
 % add toc to toc
 \newif\if@addtoctotoc
 \DeclareOption{addtoctotoc}{\@addtoctotoctrue}%
@@ -38,27 +35,6 @@
 ]{scrbook}%
 
 % --- Load packages
-% sans serif title page
-% computer modern sans serif does not have a small capitals font (which is used
-% for setting the TUM Text)
-%   http://tex.stackexchange.com/questions/16740/small-caps-with-cmss
-% The default behavior is, that TUM and LIS text is typeset using CM serif
-% If you wish, these are set also sans serif by switching to a different font
-%    http://www.linuxlibertine.org/index.php
-\if@titlepage@sansserif
-  \if@tumtext@sansserif
-    \IfFileExists{libertine.sty}{%
-      \RequirePackage[T1]{fontenc}%
-      \RequirePackage{libertine}%
-    }{%
-      \ClassWarningNoLine{tumDiss}{%
-        Missing package <libertine>.
-        Sans serif option 'seriftumtext' will be ignored.
-      }%
-    }%
-  \fi
-\fi
-
 % use manual text positioning on title page
 \if@titlepage@showlayout
   \RequirePackage[showboxes,absolute]{textpos}%
@@ -74,7 +50,7 @@
   \RequirePackage{tocbibind}%
 \fi
 
-% load color and logo packages
+% load tumcolor package (xcolor, pgfplots and a tum-plotcycle list)
 \RequirePackage[pgfplots,svgnames,x11names]{tumcolor}%
 
 % --- Document styles


### PR DESCRIPTION
Ich hatte gedacht, dass irgendwo auf der Titelseite Kapitälchen verwendet werden. Scheint nicht (mehr) der Fall zu sein, also raus damit.