### PR TITLE
Feature/gitlab auto pdf build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,30 @@
+stages:
+  - build
+  - release
+
+build:
+  stage: build
+  image: andrerichter/tum-dissertation-latex
+  script:
+    - make pdf-local
+  after_script:
+    - mkdir release
+    - FILE=`date +%Y%m%d`_dissertation_${CI_COMMIT_TAG}.pdf
+    - mv dissertation.pdf release/${FILE}
+  artifacts:
+    name: "${CI_PROJECT_NAME}_${CI_COMMIT_REF_NAME}_${CI_COMMIT_SHA}.pdf"
+    expire_in: 15 min
+    paths:
+      - release/*.pdf
+  only:
+    - tags
+
+release:
+  image: inetprocess/gitlab-release
+  stage: release
+  dependencies:
+    - build
+  script:
+    - gitlab-release release/*.pdf
+  only:
+    - tags

--- a/README.md
+++ b/README.md
@@ -83,12 +83,14 @@ The `Makefile` already has targets for building without docker, just make them d
 You can auto build and publish your dissertation on every tagged release.
 
 ### Prerequisites
-1. Use Gitlab
-2. Enable Gitlab runners for repo (https://docs.gitlab.com/ee/ci/runners/)
-_Note: http://gitlab.lrz.de/ currently does not provide shared runners._
-3. Create a `Personal Access Token` with the `api` scope (https://gitlab.com/profile/personal_access_tokens)
-4. Add the token as environment variable `GITLAB_ACCESS_TOKEN` in your dissertation repository (https://gitlab.com/USER/REPO/settings/ci_cd).
-5. Create and push a tag.
+1. Use Gitlab (e.g. gitlab.com or gitlab.lrz.de)
+2. Enable `Pipelines` for your project under `Settings > General > Permissions` (https://docs.gitlab.com/ee/ci/enable_or_disable_ci.html)
+3. Enable Gitlab runners for your project under `Settings > CI/CD` (https://docs.gitlab.com/ee/ci/runners/)
+4. Create a `Personal Access Token` with the `api` scope (https://gitlab.com/profile/personal_access_tokens)
+5. Add the token as environment variable `GITLAB_ACCESS_TOKEN` in project `Settings > CI/CD > Variables` (https://docs.gitlab.com/ee/ci/variables/#creating-a-custom-environment-variable).
+6. Create and push a tag, wait ~2mins and find your dissertation as PDF under your project tags (https://gitlab.com/USER/REPO/tags) to download.
+
+_Note: https://gitlab.lrz.de/ currently does not provide shared runners. Submit a friendly request here: https://servicedesk.lrz.de/de_
 
 ## Link list of logo resources
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You can auto build and publish your dissertation on every tagged release.
 2. Enable Gitlab runners for repo (https://docs.gitlab.com/ee/ci/runners/)
 _Note: http://gitlab.lrz.de/ currently does not provide shared runners._
 3. Create a `Personal Access Token` with the `api` scope (https://gitlab.com/profile/personal_access_tokens)
-4. Add the token as environment variable `GITLAB_ACCESS_TOKEN` in your dissertation repository (https://gitlab.com/<user>/<repo>/settings/ci_cd).
+4. Add the token as environment variable `GITLAB_ACCESS_TOKEN` in your dissertation repository (https://gitlab.com/USER/REPO/settings/ci_cd).
 5. Create and push a tag.
 
 ## Link list of logo resources

--- a/README.md
+++ b/README.md
@@ -83,14 +83,19 @@ The `Makefile` already has targets for building without docker, just make them d
 You can auto build and publish your dissertation on every tagged release.
 
 ### Prerequisites
-1. Use Gitlab (e.g. gitlab.com or gitlab.lrz.de)
-2. Enable `Pipelines` for your project under `Settings > General > Permissions` (https://docs.gitlab.com/ee/ci/enable_or_disable_ci.html)
-3. Enable Gitlab runners for your project under `Settings > CI/CD` (https://docs.gitlab.com/ee/ci/runners/)
-4. Create a `Personal Access Token` with the `api` scope (https://gitlab.com/profile/personal_access_tokens)
-5. Add the token as environment variable `GITLAB_ACCESS_TOKEN` in project `Settings > CI/CD > Variables` (https://docs.gitlab.com/ee/ci/variables/#creating-a-custom-environment-variable).
-6. Create and push a tag, wait ~2mins and find your dissertation as PDF under your project tags (https://gitlab.com/USER/REPO/tags) to download.
+1. Use Gitlab (e.g. [gitlab.com](https://www.gitlab.com) or [gitlab.lrz.de](https://gitlab.lrz.de)).
+2. [Enable Pipelines][auto_1] for your project under `Settings > General > Permissions`.
+3. [Enable Gitlab runners][auto_2] for your project under `Settings > CI/CD`.
+4. Create a [Personal Access Token][auto_3] with the `api` scope.
+5. Add the token [as environment variable][auto_4] `GITLAB_ACCESS_TOKEN` in project `Settings > CI/CD > Variables`.
+6. Create and push a tag, wait ~2mins and find your dissertation as PDF under your project tags to download (https://gitlab.com/USER/REPO/tags).
 
 _Note: https://gitlab.lrz.de/ currently does not provide shared runners. Submit a friendly request here: https://servicedesk.lrz.de/de_
+
+[auto_1]: https://docs.gitlab.com/ee/ci/enable_or_disable_ci.html
+[auto_2]: https://docs.gitlab.com/ee/ci/runners
+[auto_3]: https://gitlab.com/profile/personal_access_tokens
+[auto_4]: https://docs.gitlab.com/ee/ci/variables/#creating-a-custom-environment-variable
 
 ## Link list of logo resources
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ The TUM design guidelines lack explicit statements about how to place non-quadra
 Linux/macOS users who want to build without Docker most likely know what to do. Dependencies can be found inside `Dockerfile`.
 The `Makefile` already has targets for building without docker, just make them default.
 
+## Auto build and publish dissertation
+
+You can auto build and publish your dissertation on every tagged release.
+
+### Prerequisites
+1. Use Gitlab
+2. Enable Gitlab runners for repo (https://docs.gitlab.com/ee/ci/runners/)
+_Note: http://gitlab.lrz.de/ currently does not provide shared runners._
+3. Create a `Personal Access Token` with the `api` scope (https://gitlab.com/profile/personal_access_tokens)
+4. Add the token as environment variable `GITLAB_ACCESS_TOKEN` in your dissertation repository (https://gitlab.com/<user>/<repo>/settings/ci_cd).
+5. Create and push a tag.
+
 ## Link list of logo resources
 
 - [TUM Logo](https://portal.mytum.de/corporatedesign/vorlagen/index_Logos/dateien/TUM_Logo_blau_rgb_s)


### PR DESCRIPTION
## Enable automatic build and publish PDF on tagged releases in Gitlab.

This PR adds a `.gitlab-ci.yml` and description how you utilize this feature.
Tested with https://gitlab.com and https://gitlab.lrz.de/


## Images

![tagged-releases](https://user-images.githubusercontent.com/7462542/58491269-f9de6c80-816e-11e9-93d0-a533bf1355b3.jpg)
![ci](https://user-images.githubusercontent.com/7462542/58491270-f9de6c80-816e-11e9-967c-b37b0a53fb4c.jpg)
