### PR TITLE
Remove -it flag from docker run command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ TEX      = latexmk
 TEXFLAGS = -recorder -pdf
 TEXCLEAN = -bibtex -c
 
-DOCKER   = docker run -it --rm -v $$(pwd):$$(pwd) -w $$(pwd) \
+DOCKER   = docker run --rm -v $$(pwd):$$(pwd) -w $$(pwd) \
 	   andrerichter/tum-dissertation-latex
 
 .PHONY: docker clean crop pdf-local clean-local crop-local placeholder placeholder-local

--- a/make.bat
+++ b/make.bat
@@ -1,4 +1,4 @@
-SET docker=docker run -it --rm -v "%CD%":/diss andrerichter/tum-dissertation-latex
+SET docker=docker run --rm -v "%CD%":/diss andrerichter/tum-dissertation-latex
 
 IF "%1"=="crop" %docker% make crop-local
 IF "%1"=="" %docker% make pdf-local


### PR DESCRIPTION
I removed the option for interactive docker sessions from the Makefile. When `-it` is set the Makefile cannot be used for builds from [vscode LaTeX Workshop](https://github.com/James-Yu/LaTeX-Workshop), since docker fails with `the input device is not a TTY`. As far as I can see there is no reason why we would need to make the docker session interactive.