### PR TITLE
Corrects working directory in make.bat

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -1,4 +1,4 @@
-SET docker=docker run --rm -v "%CD%":/diss andrerichter/tum-dissertation-latex
+SET docker=docker run --rm -v "%CD%":/diss -w /diss andrerichter/tum-dissertation-latex
 
 IF "%1"=="crop" %docker% make crop-local
 IF "%1"=="" %docker% make pdf-local


### PR DESCRIPTION
The working directory is not set in make.bat, resulting in the following error:
```bat
make: *** No rule to make target 'pdf-local'.  Stop.
```

This fixes this error by specifying the working directory.