### PR TITLE
Fixes synctex files on windows using linux paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ crop:
 
 pdf-local: $(DISS)
 	$(TEX) $(TEXFLAGS) $(DISS)
+ifdef ORIGINAL_DISS_PATH
+	./fix_windows_synctex.sh
+endif
 
 clean-local:
 	$(TEX) $(TEXCLEAN)

--- a/fix_windows_synctex.sh
+++ b/fix_windows_synctex.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+echo "original diss path: $ORIGINAL_DISS_PATH"
+gzip -d "dissertation.synctex.gz"
+echo "unzipped"
+sed -i'' "s|:/diss|:${ORIGINAL_DISS_PATH//\\/\/}|g" dissertation.synctex
+echo "sed complete"
+gzip dissertation.synctex
+echo "gz complete"

--- a/fix_windows_synctex.sh
+++ b/fix_windows_synctex.sh
@@ -6,3 +6,4 @@ sed -i'' "s|:/diss|:${ORIGINAL_DISS_PATH//\\/\/}|g" dissertation.synctex
 echo "sed complete"
 gzip dissertation.synctex
 echo "gz complete"
+touch dissertation.pdf

--- a/make.bat
+++ b/make.bat
@@ -1,4 +1,4 @@
-SET docker=docker run --rm -v "%CD%":/diss -w /diss andrerichter/tum-dissertation-latex
+SET docker=docker run --rm --env ORIGINAL_DISS_PATH="%CD%" -v "%CD%":/diss -w /diss andrerichter/tum-dissertation-latex
 
 IF "%1"=="crop" %docker% make crop-local
 IF "%1"=="" %docker% make pdf-local


### PR DESCRIPTION
Syntex files produced on windows using docker were using the linux paths in the docker files.
This forces the synctex files to use the windows paths.