### PR TITLE
Set TEXINPUTS in a system independent way

### DIFF
--- a/latexmkrc
+++ b/latexmkrc
@@ -2,7 +2,8 @@
 # https://www.ctan.org/tex-archive/support/latexmk/example_rcfiles
 
 # compiler options
-$pdflatex = 'TEXINPUTS="./inc//:" pdflatex -interaction=batchmode -shell-escape -synctex=1 %O %S';
+ensure_path('TEXINPUTS', './inc//');  # include the local inc directory in the latex search path
+$pdflatex = 'pdflatex -interaction=batchmode -shell-escape -synctex=1 %O %S';
 $pdf_mode = 1;
 $bibtex_use = 1;
 


### PR DESCRIPTION
# Description

## Problem

Prepending environment variables to commands works differently (if at all) on Windows. Sadly, you can't just do `FOO=value myCommand`. For this reason, the `pdflatex` alias command in `latexmkrc` does not work on Windows.

## Fix

Use latexmk's `ensure_path()` function to be compatible with any operating system. See the [official documentation (page 54)](https://texdoc.org/serve/latexmk/0).

## Additional context

- We don't need to append ':' to the new value, since `ensure_path()` prepends this value to the existing one and fills in the system-appropriate path separators.
- Yes, I know there is a docker container, but if the tools we use are already system independent, why not employ them that way? :)

## Tests

- [x] executed `make pdf-local` on Windows successfully
- [x] executed `make pdf-local` on Linux successfully 